### PR TITLE
Fix "array_merge(): Argument #1 is not an array" warning

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -275,7 +275,7 @@ abstract class User implements UserInterface, GroupableInterface
      */
     public function getRoles()
     {
-        $roles = $this->roles;
+        $roles = $this->roles ?: [];
 
         foreach ($this->getGroups() as $group) {
             $roles = array_merge($roles, $group->getRoles());


### PR DESCRIPTION
Under some circumstances User tries to merge _null_ and array with roles, making Symfony throw the provided exception.